### PR TITLE
NL #95 - Fixing merge error

### DIFF
--- a/src/components/ExhibitPublicMap/index.js
+++ b/src/components/ExhibitPublicMap/index.js
@@ -320,10 +320,13 @@ class ExhibitPublicMap extends Component {
 
 		mapInstance.on('draw:drawstop', (e) => {
 			this.props.leafletIsEditing(false);
+      let geojsonData = this.ls_fg.toGeoJSON();
+      saveChanges(selectedRecord, geojsonData);
       // crude fix for events firing in non-intuitive sequence -- delay prevents the mouse action from getting treated as a mapClick and deselecting the record
-			window.setTimeout(function() {
-        this.isDrawing=false;
-      }.bind(this), 200);
+			// window.setTimeout(function() {
+      //
+      // }.bind(this), 200);
+      this.isDrawing=false;
 			this.allowRender=true;
 		});
 

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -109,7 +109,6 @@ function* deselectRecord(action) {
     url += `/show/${ slug }`;
     history.replace(url);
   }
-  yield put({type: ACTION_TYPE.EVENT_REFRESH_MAP_GEOMETRY});
 }
 
 function* createRecordResponseReceived(action) {


### PR DESCRIPTION
Removing erroneous reference to `EVENT_REFRESH_MAP_GEOMETRY` event.