### PR TITLE
NL #83 - Page block

### DIFF
--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -90,7 +90,7 @@ function* createRecord(action) {
 }
 
 function* selectRecord(action) {
-  const { redirect } = action.payload;
+  const { redirect } = (action.payload || {});
   if (redirect) {
     let exhibit = yield select(getExhibitCache);
     let slug = exhibit['o:slug'];
@@ -101,7 +101,7 @@ function* selectRecord(action) {
 }
 
 function* deselectRecord(action) {
-  const { redirect } = action.payload;
+  const { redirect } = (action.payload || {});
   if (redirect) {
     let exhibit = yield select(getExhibitCache);
     let slug = exhibit['o:slug'];


### PR DESCRIPTION
This pull request fixes and error that occurs when no payload is sent to the `selectRecord` and `deselectRecord` actions. As a solution, we will default the payload to an empty object to avoid `undefined` errors.